### PR TITLE
Replace Microsoft.Windows.Compatibility with actual dependency

### DIFF
--- a/StreetSmartAPI/StreetSmart.API/WPF/StreetSmart.WPF.csproj
+++ b/StreetSmartAPI/StreetSmart.API/WPF/StreetSmart.WPF.csproj
@@ -955,7 +955,7 @@
 		<PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.421302">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.7" />
+		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
 		<PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
The WPF version of the street smart api currently uses Microsoft.Windows.Compatibility. This package has a lot of dependencies that are not actually used by the package.

Only System.Drawing.Common is actually used.